### PR TITLE
configure mail-service in Kubernetes

### DIFF
--- a/mail-service/mail-service-configmap.yml
+++ b/mail-service/mail-service-configmap.yml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: mail-service-configmap
+  namespace: default
 data:
   KAFKA_HOST: "kafka-cluster"
   AUTH_HOST: "auth-service"

--- a/mail-service/mail-service-configmap.yml
+++ b/mail-service/mail-service-configmap.yml
@@ -4,4 +4,4 @@ metadata:
   name: mail-service-configmap
 data:
   KAFKA_HOST: "kafka-cluster"
-  AUTH_HOST: "authentication-service"
+  AUTH_HOST: "auth-service"

--- a/mail-service/mail-service-configmap.yml
+++ b/mail-service/mail-service-configmap.yml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mail-service-configmap
+data:
+  KAFKA_HOST: "kafka-cluster"
+  AUTH_HOST: "authentication-service"

--- a/mail-service/mail-service-configmap.yml
+++ b/mail-service/mail-service-configmap.yml
@@ -4,5 +4,5 @@ metadata:
   name: mail-service-configmap
   namespace: default
 data:
-  KAFKA_HOST: "kafka-cluster"
+  KAFKA_HOST: "kafka-cluster-kafka-bootstrap"
   AUTH_HOST: "auth-service"

--- a/mail-service/mail-service-deployment.yml
+++ b/mail-service/mail-service-deployment.yml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mail-service-v1
+  namespace: default
+  labels:
+    app: mail-service
+    version: v1
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: mail-service
+      version: v1
+  template:
+    metadata:
+      labels:
+        app: mail-service
+        version: v1
+    spec:
+      containers:
+        - name: mail-service
+          image: cichan/mail-service:prod
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8082
+          env:
+            - name: GMAIL_USER
+              valueFrom:
+                secretKeyRef:
+                  name: mail-service-secret
+                  key: GMAIL_USER
+            - name: GMAIL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: mail-service-secret
+                  key: GMAIL_PASSWORD
+            - name: KAFKA_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: mail-service-configmap
+                  key: KAFKA_HOST
+            - name: AUTH_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: mail-service-configmap
+                  key: AUTH_HOST

--- a/mail-service/mail-service-secret.yml
+++ b/mail-service/mail-service-secret.yml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mail-service-secret
+type: Opaque
+data:
+  # echo -n ${} | base64
+  GMAIL_USER: NjY4NDE3N3B0QGdtYWlsLmNvbQ==
+  GMAIL_PASSWORD: eHBsYXZqeG9iZm1zd3dpcQ==

--- a/mail-service/mail-service-secret.yml
+++ b/mail-service/mail-service-secret.yml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: mail-service-secret
+  namespace: default
 type: Opaque
 data:
   # echo -n ${} | base64

--- a/mail-service/mail-service-service.yml
+++ b/mail-service/mail-service-service.yml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: mail-servic
+  name: mail-service
   namespace: default
   labels:
     app: mail-service

--- a/mail-service/mail-service-service.yml
+++ b/mail-service/mail-service-service.yml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mail-servic
+  namespace: default
+  labels:
+    app: mail-service
+    service: mail-service
+spec:
+  type: LoadBalancer
+  selector:
+    app: mail-service
+  ports:
+    - name: mail-service
+      port: 8080
+      targetPort: 8082


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds Kubernetes configuration files for deploying the mail-service application, including a ConfigMap and a Secret with sensitive information. It also includes a Service and Deployment definition with environment variables.

### Detailed summary
- Added `mail-service-configmap.yml` defining a ConfigMap with Kafka and Auth hosts
- Added `mail-service-secret.yml` defining a Secret with Gmail credentials
- Added `mail-service-service.yml` defining a LoadBalancer Service for mail-service
- Added `mail-service-deployment.yml` defining a Deployment for mail-service with 3 replicas and environment variables for the Secret and ConfigMap

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->