### PR TITLE
configure airline-service in Kubernetes

### DIFF
--- a/airline-service/airline-service-configmap.yml
+++ b/airline-service/airline-service-configmap.yml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: airline-service-configmap
+  namespace: default
+data:
+  LIQUIBASE_SCHEMA: "public"
+  KAFKA_HOST: "kafka-cluster-kafka-bootstrap"

--- a/airline-service/airline-service-deployment.yml
+++ b/airline-service/airline-service-deployment.yml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: airline-service
-          image: cichan/airline-service:prod
+          image: cichan/airline-service:0.1.0
           imagePullPolicy: Always
           ports:
             - containerPort: 8084

--- a/airline-service/airline-service-deployment.yml
+++ b/airline-service/airline-service-deployment.yml
@@ -1,0 +1,69 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: airline-service-v1
+  namespace: default
+  labels:
+    app: airline-service
+    version: v1
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: airline-service
+      version: v1
+  template:
+    metadata:
+      labels:
+        app: airport
+        version: v1
+    spec:
+      containers:
+        - name: airline-service
+          image: cichan/airline-service:prod
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8084
+          env:
+            - name: POSTGRES_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: postgres-configmap
+                  key: POSTGRES_HOST
+            - name: POSTGRES_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: postgres-configmap
+                  key: POSTGRES_PORT
+            - name: POSTGRES_SCHEMA
+              valueFrom:
+                configMapKeyRef:
+                  name: postgres-configmap
+                  key: POSTGRES_SCHEMA
+            - name: POSTGRES_DB
+              valueFrom:
+                configMapKeyRef:
+                  name: postgres-configmap
+                  key: POSTGRES_DB
+            - name: POSTGRES_URL
+              value: jdbc:postgresql://${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}?currentSchema=${POSTGRES_SCHEMA}
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-secret
+                  key: POSTGRES_USER
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-secret
+                  key: POSTGRES_PASSWORD
+            - name: LIQUIBASE_SCHEMA
+              valueFrom:
+                configMapKeyRef:
+                  name: airline-service-configmap
+                  key: LIQUIBASE_SCHEMA
+            - name: KAFKA_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: airline-service-configmap
+                  key: KAFKA_HOST

--- a/airline-service/airline-service-service.yml
+++ b/airline-service/airline-service-service.yml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: airline-service
+  namespace: default
+  labels:
+    app: airline-service
+    service: airline-service
+spec:
+  type: LoadBalancer
+  selector:
+    app: airline-service
+  ports:
+    - name: airline-service
+      port: 8080
+      targetPort: 8084

--- a/airline-service/postgres-configmap.yml
+++ b/airline-service/postgres-configmap.yml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: postgres-configmap
+  namespace: default
+data:
+  POSTGRES_HOST: "postgres"
+  POSTGRES_PORT: "5432"
+  POSTGRES_SCHEMA: "public"
+  POSTGRES_DB: "postgres"

--- a/airline-service/postgres-secret.yml
+++ b/airline-service/postgres-secret.yml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgres-secret
+  namespace: default
+type: Opaque
+data:
+  # echo -n ${} | base64
+  POSTGRES_USER: cG9zdGdyZXM=
+  POSTGRES_PASSWORD: RmsjNTY3

--- a/airline-service/postgres-service.yml
+++ b/airline-service/postgres-service.yml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: airline-postgres
+  namespace: default
+  labels:
+    app: airline-postgres
+    service: airline-postgres
+spec:
+  type: ClusterIP
+  selector:
+    app: airline-postgres
+  ports:
+    - name: airline-postgres
+      port: 5432
+      targetPort: 5433

--- a/airline-service/postgres-stateful.yml
+++ b/airline-service/postgres-stateful.yml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: airline-postgres
+  namespace: default
+  labels:
+    app: airline-postgres
+    version: v1
+spec:
+  serviceName: airline-postgres
+  replicas: 3
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: airline-postgres
+      version: v1
+  template:
+    metadata:
+      labels:
+        app: airline-postgres
+        version: v1
+    spec:
+      containers:
+        - name: airline-postgres
+          image: postgres:15.2
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 5433
+          env:
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-secret
+                  key: POSTGRES_USER
+            - name: airline-POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-secret
+                  key: POSTGRES_PASSWORD
+          volumeMounts:
+            - name: airline-postgres-data
+              mountPath: /data/db
+            - name: airline-postgres-config
+              mountPath: /data/config
+  volumeClaimTemplates:
+    - metadata:
+        name: airline-postgres-data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 10Gi
+        storageClassName: "standard"
+    - metadata:
+        name: airline-postgres-config
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 1Gi

--- a/airline-service/postgres-stateful.yml
+++ b/airline-service/postgres-stateful.yml
@@ -24,7 +24,7 @@ spec:
       containers:
         - name: airline-postgres
           image: postgres:15.2
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           ports:
             - containerPort: 5433
           env:


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds Kubernetes configuration files for a Postgres database and an airline service with a load balancer.

### Detailed summary
- Added ConfigMap for airline service with Liquibase schema and Kafka host data
- Added Secret for Postgres database with base64 encoded username and password data
- Added ConfigMap for Postgres database with host, port, schema, and database name data
- Added Service for airline Postgres database with ClusterIP and port configuration
- Added StatefulSet for airline Postgres database with 3 replicas and volume claim templates for data and config directories
- Added Deployment for airline service with 3 replicas and container configuration for Postgres database URL, user, and password, Liquibase schema, and Kafka host.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->