### PR TITLE
tweak bugs

### DIFF
--- a/micro-airport-location/airport-location-deployment.yml
+++ b/micro-airport-location/airport-location-deployment.yml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: airport-location
-          image: cichan/micro-airport-location:0.1.0
+          image: cichan/micro-airport-location:0.1.1
           imagePullPolicy: Always
           ports:
             - containerPort: 8080

--- a/micro-airport-location/redis-deployment.yml
+++ b/micro-airport-location/redis-deployment.yml
@@ -36,3 +36,26 @@ spec:
         - name: redis-config
           persistentVolumeClaim:
             claimName: redis-config
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: redis-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: redis-config
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+---


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the micro-airport-location image and adds persistent volume claims for Redis data and config.

### Detailed summary
- Updated micro-airport-location image from `cichan/micro-airport-location:0.1.0` to `cichan/micro-airport-location:0.1.1`.
- Added a new persistent volume claim for Redis data with a storage size of 10Gi.
- Updated the persistent volume claim for Redis config to have a storage size of 1Gi.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->