### PR TITLE
fixed mongo connection bug

### DIFF
--- a/micro-airport-location/airport-location-deployment.yml
+++ b/micro-airport-location/airport-location-deployment.yml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: airport-location
-          image: cichan/micro-airport-location:0.1.1
+          image: cichan/micro-airport-location:0.1.2
           imagePullPolicy: Always
           ports:
             - containerPort: 8080
@@ -30,6 +30,11 @@ spec:
                 configMapKeyRef:
                   name: mongo-configmap
                   key: MONGO_HOST
+            - name: MONGO_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: mongo-configmap
+                  key: MONGO_PORT
             - name: MONGO_AUTH_DB
               valueFrom:
                 configMapKeyRef:

--- a/micro-airport-location/mongo-configmap.yml
+++ b/micro-airport-location/mongo-configmap.yml
@@ -5,5 +5,6 @@ metadata:
   namespace: default
 data:
   MONGO_HOST: "mongo"
+  MONGO_PORT: "27017"
   MONGO_AUTH_DB: "admin"
   MONGO_DB: "micro-airport-location"


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds a new environment variable to the `airport-location` container and updates the image version. It also modifies the `mongo-configmap.yml` file to include the `MONGO_PORT` key.

### Detailed summary
- Added `MONGO_PORT` environment variable to `airport-location` container
- Updated `cichan/micro-airport-location` image from version `0.1.1` to `0.1.2`
- Modified `mongo-configmap.yml` to include `MONGO_PORT` key with value `27017`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->