### PR TITLE
tweak kafka bugs

### DIFF
--- a/kafka.yml
+++ b/kafka.yml
@@ -6,7 +6,7 @@ metadata:
 spec:
   kafka:
     version: 3.4.0
-    replicas: 3
+    replicas: 1
     listeners:
       - name: plain
         port: 9092
@@ -17,18 +17,21 @@ spec:
         type: internal
         tls: true
     config:
-      offsets.topic.replication.factor: 3
-      transaction.state.log.replication.factor: 3
-      transaction.state.log.min.isr: 2
-      default.replication.factor: 3
-      min.insync.replicas: 2
+      offsets.topic.replication.factor: 1
+      transaction.state.log.replication.factor: 1
+      transaction.state.log.min.isr: 1
+      default.replication.factor: 1
+      min.insync.replicas: 1
       inter.broker.protocol.version: "3.4"
     storage:
-      type: persistent-claim
-      size: 100Gi
-      deleteClaim: false
+      type: jbod
+      volumes:
+        - id: 0
+          type: persistent-claim
+          size: 100Gi
+          deleteClaim: false
   zookeeper:
-    replicas: 3
+    replicas: 1
     storage:
       type: persistent-claim
       size: 100Gi


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR reduces the replication factor and the number of replicas for Kafka and Zookeeper to 1, and changes the storage type for Kafka from persistent-claim to jbod.

### Detailed summary
- Reduced Kafka and Zookeeper replication factor and replicas to 1
- Changed Kafka storage type from persistent-claim to jbod
- Added volumes configuration for Kafka storage

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->