### PR TITLE
tweak bugs

### DIFF
--- a/airline-service/airline-service-configmap.yml
+++ b/airline-service/airline-service-configmap.yml
@@ -4,5 +4,5 @@ metadata:
   name: airline-service-configmap
   namespace: default
 data:
-  LIQUIBASE_SCHEMA: "public"
+  LIQUIBASE_LIQUIBASE_SCHEMA_NAME: "public"
   KAFKA_HOST: "kafka-cluster-kafka-bootstrap"

--- a/airline-service/airline-service-deployment.yml
+++ b/airline-service/airline-service-deployment.yml
@@ -15,53 +15,53 @@ spec:
   template:
     metadata:
       labels:
-        app: airport
+        app: airline-service
         version: v1
     spec:
       containers:
         - name: airline-service
-          image: cichan/airline-service:0.1.0
+          image: cichan/airline-service:0.1.1
           imagePullPolicy: Always
           ports:
-            - containerPort: 8084
+            - containerPort: 8080
           env:
             - name: POSTGRES_HOST
               valueFrom:
                 configMapKeyRef:
-                  name: postgres-configmap
+                  name: postgres-airline-configmap
                   key: POSTGRES_HOST
             - name: POSTGRES_PORT
               valueFrom:
                 configMapKeyRef:
-                  name: postgres-configmap
+                  name: postgres-airline-configmap
                   key: POSTGRES_PORT
             - name: POSTGRES_SCHEMA
               valueFrom:
                 configMapKeyRef:
-                  name: postgres-configmap
+                  name: postgres-airline-configmap
                   key: POSTGRES_SCHEMA
             - name: POSTGRES_DB
               valueFrom:
                 configMapKeyRef:
-                  name: postgres-configmap
+                  name: postgres-airline-configmap
                   key: POSTGRES_DB
             - name: POSTGRES_URL
               value: jdbc:postgresql://${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}?currentSchema=${POSTGRES_SCHEMA}
             - name: POSTGRES_USER
               valueFrom:
                 secretKeyRef:
-                  name: postgres-secret
+                  name: postgres-airline-secret
                   key: POSTGRES_USER
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: postgres-secret
+                  name: postgres-airline-secret
                   key: POSTGRES_PASSWORD
-            - name: LIQUIBASE_SCHEMA
+            - name: LIQUIBASE_LIQUIBASE_SCHEMA_NAME
               valueFrom:
                 configMapKeyRef:
                   name: airline-service-configmap
-                  key: LIQUIBASE_SCHEMA
+                  key: LIQUIBASE_LIQUIBASE_SCHEMA_NAME
             - name: KAFKA_HOST
               valueFrom:
                 configMapKeyRef:

--- a/airline-service/airline-service-service.yml
+++ b/airline-service/airline-service-service.yml
@@ -7,10 +7,10 @@ metadata:
     app: airline-service
     service: airline-service
 spec:
-  type: LoadBalancer
+  type: ClusterIP
   selector:
     app: airline-service
   ports:
     - name: airline-service
       port: 8080
-      targetPort: 8084
+      targetPort: 8080

--- a/airline-service/postgres-configmap.yml
+++ b/airline-service/postgres-configmap.yml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: postgres-configmap
+  name: postgres-airline-configmap
   namespace: default
 data:
-  POSTGRES_HOST: "postgres"
-  POSTGRES_PORT: "5432"
+  POSTGRES_HOST: "airline-postgres"
+  POSTGRES_PORT: "5433"
   POSTGRES_SCHEMA: "public"
   POSTGRES_DB: "postgres"

--- a/airline-service/postgres-secret.yml
+++ b/airline-service/postgres-secret.yml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: postgres-secret
+  name: postgres-airline-secret
   namespace: default
 type: Opaque
 data:

--- a/airline-service/postgres-service.yml
+++ b/airline-service/postgres-service.yml
@@ -12,5 +12,5 @@ spec:
     app: airline-postgres
   ports:
     - name: airline-postgres
-      port: 5432
-      targetPort: 5433
+      port: 5433
+      targetPort: 5432

--- a/airline-service/postgres-stateful.yml
+++ b/airline-service/postgres-stateful.yml
@@ -26,17 +26,17 @@ spec:
           image: postgres:15.2
           imagePullPolicy: Always
           ports:
-            - containerPort: 5433
+            - containerPort: 5432
           env:
             - name: POSTGRES_USER
               valueFrom:
                 secretKeyRef:
-                  name: postgres-secret
+                  name: postgres-airline-secret
                   key: POSTGRES_USER
-            - name: airline-POSTGRES_PASSWORD
+            - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: postgres-secret
+                  name: postgres-airline-secret
                   key: POSTGRES_PASSWORD
           volumeMounts:
             - name: airline-postgres-data

--- a/authentication-service/auth-service-deployment.yml
+++ b/authentication-service/auth-service-deployment.yml
@@ -20,10 +20,10 @@ spec:
     spec:
       containers:
         - name: auth-service
-          image: cichan/authentication-service:0.1.0
+          image: cichan/authentication-service:0.1.1
           imagePullPolicy: Always
           ports:
-            - containerPort: 8083
+            - containerPort: 8080
           env:
             - name: KAFKA_HOST
               valueFrom:

--- a/authentication-service/auth-service-service.yml
+++ b/authentication-service/auth-service-service.yml
@@ -7,10 +7,10 @@ metadata:
     app: auth-service
     service: auth-service
 spec:
-  type: LoadBalancer
+  type: ClusterIP
   selector:
     app: auth-service
   ports:
     - name: auth-service
       port: 8080
-      targetPort: 8083
+      targetPort: 8080

--- a/mail-service/mail-service-deployment.yml
+++ b/mail-service/mail-service-deployment.yml
@@ -20,10 +20,10 @@ spec:
     spec:
       containers:
         - name: mail-service
-          image: cichan/mail-service:0.1.0
+          image: cichan/mail-service:0.1.1
           imagePullPolicy: Always
           ports:
-            - containerPort: 8082
+            - containerPort: 8080
           env:
             - name: GMAIL_USER
               valueFrom:

--- a/mail-service/mail-service-service.yml
+++ b/mail-service/mail-service-service.yml
@@ -7,10 +7,10 @@ metadata:
     app: mail-service
     service: mail-service
 spec:
-  type: LoadBalancer
+  type: ClusterIP
   selector:
     app: mail-service
   ports:
     - name: mail-service
       port: 8080
-      targetPort: 8082
+      targetPort: 8080

--- a/micro-airport-core/airport-core-configmap.yml
+++ b/micro-airport-core/airport-core-configmap.yml
@@ -4,7 +4,7 @@ metadata:
   name: airport-core-configmap
   namespace: default
 data:
-  LIQUIBASE_SCHEMA: "public"
+  LIQUIBASE_LIQUIBASE_SCHEMA_NAME: "public"
   KAFKA_HOST: "kafka-cluster-kafka-bootstrap"
   AIRPORT_LOCATION_HOST: "airport-location"
   AUTH_HOST: "auth-service"

--- a/micro-airport-core/airport-core-deployment.yml
+++ b/micro-airport-core/airport-core-deployment.yml
@@ -15,48 +15,53 @@ spec:
   template:
     metadata:
       labels:
-        app: airport
+        app: airport-core
         version: v1
     spec:
       containers:
         - name: airport-core
-          image: cichan/micro-airport-core:0.1.0
+          image: cichan/micro-airport-core:0.1.1
           imagePullPolicy: Always
           ports:
-            - containerPort: 8081
+            - containerPort: 8080
           env:
             - name: POSTGRES_HOST
               valueFrom:
                 configMapKeyRef:
-                  name: postgres-configmap
+                  name: postgres-core-configmap
                   key: POSTGRES_HOST
+            - name: POSTGRES_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: postgres-core-configmap
+                  key: POSTGRES_PORT
             - name: POSTGRES_SCHEMA
               valueFrom:
                 configMapKeyRef:
-                  name: postgres-configmap
+                  name: postgres-core-configmap
                   key: POSTGRES_SCHEMA
             - name: POSTGRES_DB
               valueFrom:
                 configMapKeyRef:
-                  name: postgres-configmap
+                  name: postgres-core-configmap
                   key: POSTGRES_DB
             - name: POSTGRES_URL
-              value: jdbc:postgresql://${POSTGRES_HOST}:5432/${POSTGRES_DB}?currentSchema=${POSTGRES_SCHEMA}
+              value: jdbc:postgresql://${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}?currentSchema=${POSTGRES_SCHEMA}
             - name: POSTGRES_USER
               valueFrom:
                 secretKeyRef:
-                  name: postgres-secret
+                  name: postgres-core-secret
                   key: POSTGRES_USER
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: postgres-secret
+                  name: postgres-core-secret
                   key: POSTGRES_PASSWORD
-            - name: LIQUIBASE_SCHEMA
+            - name: LIQUIBASE_LIQUIBASE_SCHEMA_NAME
               valueFrom:
                 configMapKeyRef:
                   name: airport-core-configmap
-                  key: LIQUIBASE_SCHEMA
+                  key: LIQUIBASE_LIQUIBASE_SCHEMA_NAME
             - name: KAFKA_HOST
               valueFrom:
                 configMapKeyRef:
@@ -67,3 +72,13 @@ spec:
                 configMapKeyRef:
                   name: airport-core-configmap
                   key: AIRPORT_LOCATION_HOST
+            - name: AUTH_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: airport-core-configmap
+                  key: AUTH_HOST
+            - name: AIRLINE_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: airport-core-configmap
+                  key: AIRLINE_HOST

--- a/micro-airport-core/airport-core-service.yml
+++ b/micro-airport-core/airport-core-service.yml
@@ -7,10 +7,10 @@ metadata:
     app: airport-core
     service: airport-core
 spec:
-  type: LoadBalancer
+  type: ClusterIP
   selector:
     app: airport-core
   ports:
     - name: airport-core
       port: 8080
-      targetPort: 8081
+      targetPort: 8080

--- a/micro-airport-core/postgres-configmap.yml
+++ b/micro-airport-core/postgres-configmap.yml
@@ -1,9 +1,10 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: postgres-configmap
+  name: postgres-core-configmap
   namespace: default
 data:
-  POSTGRES_HOST: "postgres"
+  POSTGRES_HOST: "core-postgres"
+  POSTGRES_PORT: "5432"
   POSTGRES_SCHEMA: "public"
   POSTGRES_DB: "postgres"

--- a/micro-airport-core/postgres-secret.yml
+++ b/micro-airport-core/postgres-secret.yml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: postgres-secret
+  name: postgres-core-secret
   namespace: default
 type: Opaque
 data:

--- a/micro-airport-core/postgres-stateful.yml
+++ b/micro-airport-core/postgres-stateful.yml
@@ -31,12 +31,12 @@ spec:
             - name: POSTGRES_USER
               valueFrom:
                 secretKeyRef:
-                  name: postgres-secret
+                  name: postgres-core-secret
                   key: POSTGRES_USER
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: postgres-secret
+                  name: postgres-core-secret
                   key: POSTGRES_PASSWORD
           volumeMounts:
             - name: core-postgres-data

--- a/micro-airport-location/airport-location-service.yml
+++ b/micro-airport-location/airport-location-service.yml
@@ -7,7 +7,7 @@ metadata:
     app: airport-location
     service: airport-location
 spec:
-  type: LoadBalancer
+  type: ClusterIP
   selector:
     app: airport-location
   ports:

--- a/micro-airport-location/mongo-service.yml
+++ b/micro-airport-location/mongo-service.yml
@@ -7,6 +7,7 @@ metadata:
     app: mongo
     service: mongo
 spec:
+  type: ClusterIP
   selector:
     app: mongo
   ports:

--- a/micro-airport-location/redis-service.yml
+++ b/micro-airport-location/redis-service.yml
@@ -7,6 +7,7 @@ metadata:
     app: redis
     service: redis
 spec:
+  type: ClusterIP
   selector:
     app: redis
   ports:


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates several Kubernetes service and deployment configurations, as well as secrets and config maps, for the micro-airport application. The changes include updating port and target port numbers, changing service types from LoadBalancer to ClusterIP, renaming secrets and config maps, and updating container images.

### Detailed summary
- Updated service types for mongo, redis, airport-location, auth-service, mail-service, and airline-service
- Renamed secrets for postgres in airport-core and airline-service
- Renamed config maps for postgres in airport-core and airline-service
- Updated target port numbers for airport-core, auth-service, mail-service, and airline-service
- Updated container images for mail-service, airline-service, and airport-core
- Updated LIQUIBASE_LIQUIBASE_SCHEMA_NAME in airline-service and airport-core config maps
- Added POSTGRES_PORT to airport-core config map
- Added AUTH_HOST and AIRLINE_HOST to airport-core config map

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->