### PR TITLE
K8s Ingress

### DIFF
--- a/ingress.yml
+++ b/ingress.yml
@@ -30,3 +30,73 @@ spec:
                 name: airport-location
                 port:
                   number: 8080
+          - path: /airplanes
+            pathType: Prefix
+            backend:
+              service:
+                name: airport-core
+                port:
+                  number: 8080
+          - path: /flights
+            pathType: Prefix
+            backend:
+              service:
+                name: airport-core
+                port:
+                  number: 8080
+          - path: /tickets
+            pathType: Prefix
+            backend:
+              service:
+                name: airport-core
+                port:
+                  number: 8080
+          - path: /users
+            pathType: Prefix
+            backend:
+              service:
+                name: airport-core
+                port:
+                  number: 8080
+          - path: /refresh
+            pathType: Prefix
+            backend:
+              service:
+                name: auth-service
+                port:
+                  number: 8080
+          - path: /password
+            pathType: Prefix
+            backend:
+              service:
+                name: auth-service
+                port:
+                  number: 8080
+          - path: /extract-username
+            pathType: Prefix
+            backend:
+              service:
+                name: auth-service
+                port:
+                  number: 8080
+          - path: /valid-access-token
+            pathType: Prefix
+            backend:
+              service:
+                name: auth-service
+                port:
+                  number: 8080
+          - path: /generate-token
+            pathType: Prefix
+            backend:
+              service:
+                name: auth-service
+                port:
+                  number: 8080
+          - path: /airlines
+            pathType: Prefix
+            backend:
+              service:
+                name: airline-service
+                port:
+                  number: 8080

--- a/ingress.yml
+++ b/ingress.yml
@@ -1,0 +1,32 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingressgateway
+  namespace: default
+  annotations:
+    kubernetes.io/ingress.class: "istio"
+spec:
+  rules:
+    - http:
+        paths:
+          - path: /airports
+            pathType: Prefix
+            backend:
+              service:
+                name: airport-location
+                port:
+                  number: 8080
+          - path: /cities
+            pathType: Prefix
+            backend:
+              service:
+                name: airport-location
+                port:
+                  number: 8080
+          - path: /countries
+            pathType: Prefix
+            backend:
+              service:
+                name: airport-location
+                port:
+                  number: 8080


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds an ingress configuration to route traffic to different services based on the path. 

### Detailed summary
- Added `ingress.yml` file
- Configured `Ingress` resource with `metadata` and `spec` fields
- Added `annotations` to specify the ingress class as `istio`
- Configured `rules` with `http` paths and their corresponding `backend` services
- Added paths for `/airports`, `/cities`, `/countries`, `/airplanes`, `/flights`, `/tickets`, `/users`, `/refresh`, `/password`, `/extract-username`, `/valid-access-token`, and `/generate-token`
- Routed traffic to `airport-location`, `airport-core`, `auth-service`, and `airline-service` services

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->