### PR TITLE
setup runners for k8s-ci

### DIFF
--- a/airline-service/airline-service-deployment.yml
+++ b/airline-service/airline-service-deployment.yml
@@ -7,11 +7,16 @@ metadata:
     app: airline-service
     version: v1
 spec:
-  replicas: 3
   selector:
     matchLabels:
       app: airline-service
       version: v1
+  replicas: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 1
   template:
     metadata:
       labels:

--- a/airline-service/airline-service-runner.yml
+++ b/airline-service/airline-service-runner.yml
@@ -1,0 +1,24 @@
+apiVersion: actions.summerwind.dev/v1alpha1
+kind: RunnerDeployment
+metadata:
+  name: airline-service-github-runner
+  namespace: default
+spec:
+  replicas: 1
+  template:
+    spec:
+      serviceAccountName: github-runner-sa
+      automountServiceAccountToken: true
+      image: summerwind/actions-runner-dind
+      dockerdWithinRunnerContainer: true
+      labels:
+        - airline-service-k8s
+      repository: cichan02/airline-service
+      workVolumeClaimTemplate:
+        storageClassName: "standard"
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 5Gi
+      env: []

--- a/authentication-service/auth-service-deployment.yml
+++ b/authentication-service/auth-service-deployment.yml
@@ -7,11 +7,16 @@ metadata:
     app: auth-service
     version: v1
 spec:
-  replicas: 3
   selector:
     matchLabels:
       app: auth-service
       version: v1
+  replicas: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 1
   template:
     metadata:
       labels:

--- a/authentication-service/auth-service-runner.yml
+++ b/authentication-service/auth-service-runner.yml
@@ -1,0 +1,24 @@
+apiVersion: actions.summerwind.dev/v1alpha1
+kind: RunnerDeployment
+metadata:
+  name: auth-service-github-runner
+  namespace: default
+spec:
+  replicas: 1
+  template:
+    spec:
+      serviceAccountName: github-runner-sa
+      automountServiceAccountToken: true
+      image: summerwind/actions-runner-dind
+      dockerdWithinRunnerContainer: true
+      labels:
+        - auth-service-k8s
+      repository: cichan02/authentication-service
+      workVolumeClaimTemplate:
+        storageClassName: "standard"
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 5Gi
+      env: []

--- a/github-runner-sa.yml
+++ b/github-runner-sa.yml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: github-runner-sa
+  namespace: default
+automountServiceAccountToken: true
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: github-runner-cluster-role-binding
+  namespace: default
+subjects:
+  - kind: ServiceAccount
+    name: github-runner-sa
+    namespace: default
+    apiGroup: ""
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/mail-service/mail-service-deployment.yml
+++ b/mail-service/mail-service-deployment.yml
@@ -7,11 +7,16 @@ metadata:
     app: mail-service
     version: v1
 spec:
-  replicas: 3
   selector:
     matchLabels:
       app: mail-service
       version: v1
+  replicas: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 1
   template:
     metadata:
       labels:

--- a/mail-service/mail-service-runner.yml
+++ b/mail-service/mail-service-runner.yml
@@ -1,0 +1,24 @@
+apiVersion: actions.summerwind.dev/v1alpha1
+kind: RunnerDeployment
+metadata:
+  name: mail-service-github-runner
+  namespace: default
+spec:
+  replicas: 1
+  template:
+    spec:
+      serviceAccountName: github-runner-sa
+      automountServiceAccountToken: true
+      image: summerwind/actions-runner-dind
+      dockerdWithinRunnerContainer: true
+      labels:
+        - mail-service-k8s
+      repository: cichan02/mail-service
+      workVolumeClaimTemplate:
+        storageClassName: "standard"
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 5Gi
+      env: []

--- a/micro-airport-core/airport-core-deployment.yml
+++ b/micro-airport-core/airport-core-deployment.yml
@@ -7,11 +7,16 @@ metadata:
     app: airport-core
     version: v1
 spec:
-  replicas: 3
   selector:
     matchLabels:
       app: airport-core
       version: v1
+  replicas: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 1
   template:
     metadata:
       labels:

--- a/micro-airport-core/airport-core-runner.yml
+++ b/micro-airport-core/airport-core-runner.yml
@@ -1,0 +1,24 @@
+apiVersion: actions.summerwind.dev/v1alpha1
+kind: RunnerDeployment
+metadata:
+  name: airport-core-github-runner
+  namespace: default
+spec:
+  replicas: 1
+  template:
+    spec:
+      serviceAccountName: github-runner-sa
+      automountServiceAccountToken: true
+      image: summerwind/actions-runner-dind
+      dockerdWithinRunnerContainer: true
+      labels:
+        - airport-core-k8s
+      repository: cichan02/micro-airport-core
+      workVolumeClaimTemplate:
+        storageClassName: "standard"
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 5Gi
+      env: []

--- a/micro-airport-location/airport-location-deployment.yml
+++ b/micro-airport-location/airport-location-deployment.yml
@@ -7,11 +7,16 @@ metadata:
     app: airport-location
     version: v1
 spec:
-  replicas: 3
   selector:
     matchLabels:
       app: airport-location
       version: v1
+  replicas: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 1
   template:
     metadata:
       labels:

--- a/micro-airport-location/airport-location-runner.yml
+++ b/micro-airport-location/airport-location-runner.yml
@@ -1,0 +1,24 @@
+apiVersion: actions.summerwind.dev/v1alpha1
+kind: RunnerDeployment
+metadata:
+  name: airport-location-github-runner
+  namespace: default
+spec:
+  replicas: 1
+  template:
+    spec:
+      serviceAccountName: github-runner-sa
+      automountServiceAccountToken: true
+      image: summerwind/actions-runner-dind
+      dockerdWithinRunnerContainer: true
+      labels:
+        - airport-location-k8s
+      repository: cichan02/micro-airport-location
+      workVolumeClaimTemplate:
+        storageClassName: "standard"
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 5Gi
+      env: []


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds Kubernetes deployment and runner files for multiple services. 

### Detailed summary
- Added deployment files for `mail-service`, `airport-core`, `airline-service`, `auth-service`, and `airport-location`
- Added service account and cluster role binding files for `github-runner-sa`
- Added runner deployment files for `mail-service`, `airport-core`, `airline-service`, `auth-service`, and `airport-location` services.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->